### PR TITLE
Reduced timeout to get external item (image)

### DIFF
--- a/email2pdf2/email2pdf2.py
+++ b/email2pdf2/email2pdf2.py
@@ -485,7 +485,7 @@ def can_url_fetch(src):
     try:
         encoded_src = src.replace(" ", "%20")
         req = Request(encoded_src)
-        urlopen(req)
+        urlopen(req, timeout=10)  # 20220111 added timeout
     except HTTPError:
         return False
     except URLError:

--- a/email2pdf2/email2pdf2.py
+++ b/email2pdf2/email2pdf2.py
@@ -485,7 +485,7 @@ def can_url_fetch(src):
     try:
         encoded_src = src.replace(" ", "%20")
         req = Request(encoded_src)
-        urlopen(req, timeout=10)  # 20220111 added timeout
+        urlopen(req, timeout=10)  # Reduced timeout to avoid long try on broken external link
     except HTTPError:
         return False
     except URLError:


### PR DESCRIPTION
When an url is broken, the default timeout is too long. With multiple icons (by example) and a global process time too long, the email2pdf process exited with error.